### PR TITLE
요청 스키마 validation 예제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/github/hojoungjang/tekkencombomaker/controller/ComboController.java
+++ b/src/main/java/com/github/hojoungjang/tekkencombomaker/controller/ComboController.java
@@ -8,6 +8,7 @@ import com.github.hojoungjang.tekkencombomaker.service.ComboService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,7 +36,7 @@ public class ComboController {
     }
 
     @PostMapping
-    public ResponseEntity<Combo> createCombo(@RequestBody CreateComboRequest request) {
+    public ResponseEntity<Combo> createCombo(@RequestBody @Validated CreateComboRequest request) {
         Combo combo = comboService.createCombo(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(combo);
     }

--- a/src/main/java/com/github/hojoungjang/tekkencombomaker/dto/CreateComboRequest.java
+++ b/src/main/java/com/github/hojoungjang/tekkencombomaker/dto/CreateComboRequest.java
@@ -1,6 +1,8 @@
 package com.github.hojoungjang.tekkencombomaker.dto;
 
 import com.github.hojoungjang.tekkencombomaker.domain.Combo;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class CreateComboRequest {
+    @NotNull
     private String name;
+
+    @NotNull
     private String command;
 
     public Combo toEntity() {

--- a/src/test/java/com/github/hojoungjang/tekkencombomaker/controller/ComboControllerTest.java
+++ b/src/test/java/com/github/hojoungjang/tekkencombomaker/controller/ComboControllerTest.java
@@ -70,6 +70,27 @@ class ComboControllerTest {
         assertThat(combos.get(0).getCommand()).isEqualTo(command);
     }
 
+    @DisplayName("createCombo: 콤보 데이터 요청 validation 실패.")
+    @Test
+    public void createComboRequestValidation() throws Exception {
+        // given
+        final String url = "/api/v1/combos";
+        final String name = "Phoenix Smasher";
+        final String command = null;
+        final CreateComboRequest request = new CreateComboRequest(name, command);
+
+        final String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions result = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(requestBody));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+
     @DisplayName("getComboById: 콤보 데이터를 불러오는데 성공.")
     @Test
     public void getComboById() throws Exception {


### PR DESCRIPTION
### 의존성 추가
```
implementation 'org.springframework.boot:spring-boot-starter-validation'
```

### DTO 클래스 필드에 annotation 추가

문자열
`@NotNull` - `null` 허용하지 않음
`@NotEmpty` - `null`, 빈문자열 또는 공백만으로 채워진 문자열 허용하지 않음
`@NotBlank` - `null`, 빈문자열 허용하지 않음
`@Size(min=?, max=?)` - 최소/최대 길이 제한
`@Null` - null 만 가능

숫자
`@Positive` - 양수만 허용
`@PositiveOrZero` - 양수와 0 허용
`@Negative` - 음수만 허용
`@NegativeOrZero` - 음수와 0 허용
`@Min(?)` - 최솟값 제한
`@Max(?)` - 최댓값 제한

정규식
`@Email` - 이메일 형식만 허용
`@Pattern(regexp="?") - 작성한 정규식에 맞는 문자열만 허용

### Request body 에 `@Validated` annotation 추가
```java
@RequestBody @Validated AddRequest request
```
